### PR TITLE
Add B5ZE module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@
 NervesTime.RTC implementation for common Abracon Real-time clock modules. The
 following are supported:
 
-* [AB-RTCMC-32.768kHz-IBO5-S3](https://abracon.com/realtimeclock/AB-RTCMC-32.768kHz-IBO5-S3.pdf)
+* `NervesTime.RTC.Abracon.IBO5` - [AB-RTCMC-32.768kHz-IBO5-S3]
+* `NervesTime.RTC.Abracon.B5ZE` - [AB-RTCMC-32.768kHz-B5ZE-S3]
+
+[AB-RTCMC-32.768kHz-IBO5-S3]: https://abracon.com/Support/AppsManuals/Precisiontiming/Application%20Manual%20AB-RTCMC-32.768kHz-IBO5-S3.pdf
+[AB-RTCMC-32.768kHz-B5ZE-S3]: https://abracon.com/realtimeclock/AB-RTCMC-32.768kHz-B5ZE-S3-Application-Manual.pdf
 
 ## Using
 

--- a/lib/nerves_time/rtc/abracon/b5ze.ex
+++ b/lib/nerves_time/rtc/abracon/b5ze.ex
@@ -1,0 +1,89 @@
+defmodule NervesTime.RTC.Abracon.B5ZE do
+  @moduledoc """
+  Abracon AB-RTCMC-32.768kHz-B5ZE-S3 RTC implementation for NervesTime
+
+  To configure NervesTime to use this module, update the `:nerves_time` application
+  environment like this:
+
+  ```elixir
+  config :nerves_time, rtc: NervesTime.RTC.Abracon.B5ZE
+  ```
+
+  If not using `"i2c-1"` or the default I2C bus address, specify them like this:
+
+  ```elixir
+  config :nerves_time, rtc: {NervesTime.RTC.Abracon.B5ZE, [bus_name: "i2c-2", address: 0x68]}
+  ```
+
+  Check the logs for error messages if the RTC doesn't appear to work.
+
+  See https://abracon.com/realtimeclock/AB-RTCMC-32.768kHz-B5ZE-S3-Application-Manual.pdf
+  for implementation details.
+  """
+
+  @behaviour NervesTime.RealTimeClock
+
+  require Logger
+
+  alias Circuits.I2C
+  alias NervesTime.RTC.Abracon.B5ZE.{Configuration, Date}
+
+  @default_bus_name "i2c-1"
+  @default_address 0x68
+
+  @typedoc false
+  @type state :: %{
+          i2c: I2C.bus(),
+          bus_name: String.t(),
+          address: I2C.address(),
+          config: Configuration.t()
+        }
+
+  @impl NervesTime.RealTimeClock
+  def init(args) do
+    bus_name = Keyword.get(args, :bus_name, @default_bus_name)
+    address = Keyword.get(args, :address, @default_address)
+
+    with {:ok, i2c} <- I2C.open(bus_name),
+         {:ok, config} <- probe(i2c, address) do
+      {:ok, %{i2c: i2c, bus_name: bus_name, address: address, config: config}}
+    end
+  end
+
+  @impl NervesTime.RealTimeClock
+  def terminate(_state), do: :ok
+
+  @impl NervesTime.RealTimeClock
+  def set_time(state, now) do
+    with {:ok, registers} <- Date.encode(now),
+         :ok <- I2C.write(state.i2c, state.address, [0x3, registers]) do
+      state
+    else
+      error ->
+        _ = Logger.error("Error setting Abracon RTC to #{inspect(now)}: #{inspect(error)}")
+        state
+    end
+  end
+
+  @impl NervesTime.RealTimeClock
+  def get_time(state) do
+    with {:ok, registers} <- I2C.write_read(state.i2c, state.address, <<0x3>>, 7),
+         {:ok, time} <- Date.decode(registers) do
+      {:ok, time, state}
+    else
+      any_error ->
+        _ = Logger.error("Abracon RTC not set or has an error: #{inspect(any_error)}")
+        {:unset, state}
+    end
+  end
+
+  defp probe(i2c, address) do
+    case I2C.write_read(i2c, address, <<0x0>>, 3) do
+      {:ok, cfg_info} ->
+        Configuration.decode(cfg_info)
+
+      {:error, :i2c_nak} ->
+        {:error, "RTC not found at #{address}"}
+    end
+  end
+end

--- a/lib/nerves_time/rtc/abracon/b5ze/configuration.ex
+++ b/lib/nerves_time/rtc/abracon/b5ze/configuration.ex
@@ -1,0 +1,64 @@
+defmodule NervesTime.RTC.Abracon.B5ZE.Configuration do
+  @type bit() :: 0 | 1
+  @type t :: %{
+          stop: bit(),
+          sr: bit(),
+          twelve_hour: bit(),
+          sie: bit(),
+          aie: bit(),
+          cie: bit(),
+          wtaf: bit(),
+          ctaf: bit(),
+          ctbf: bit(),
+          sf: bit(),
+          af: bit(),
+          wtaie: bit(),
+          ctaie: bit(),
+          ctbie: bit(),
+          battery: 0..7,
+          bsf: bit(),
+          blf: bit(),
+          bsei: bit(),
+          blie: bit()
+        }
+
+  @spec decode(<<_::24>>) :: {:ok, t()} | {:error, any()}
+  def decode(
+        <<0::1, 0::1, stop::1, sr::1, twelve_hour::1, sie::1, aie::1, cie::1, wtaf::1, ctaf::1,
+          ctbf::1, sf::1, af::1, wtaie::1, ctaie::1, ctbie::1, battery::3, _unused::1, bsf::1,
+          blf::1, bsei::1, blie::1>>
+      ) do
+    config = %{
+      stop: stop,
+      sr: sr,
+      twelve_hour: twelve_hour,
+      sie: sie,
+      aie: aie,
+      cie: cie,
+      wtaf: wtaf,
+      ctaf: ctaf,
+      ctbf: ctbf,
+      sf: sf,
+      af: af,
+      wtaie: wtaie,
+      ctaie: ctaie,
+      ctbie: ctbie,
+      battery: battery,
+      bsf: bsf,
+      blf: blf,
+      bsei: bsei,
+      blie: blie
+    }
+
+    {:ok, config}
+  end
+
+  def decode(_other), do: {:error, :invalid}
+
+  @spec encode(t()) :: <<_::24>>
+  def encode(cfg) do
+    <<0::1, 0::1, cfg.stop::1, cfg.sr::1, cfg.twelve_hour::1, cfg.sie::1, cfg.aie::1, cfg.cie::1,
+      cfg.wtaf::1, cfg.ctaf::1, cfg.ctbf::1, cfg.sf::1, cfg.af::1, cfg.wtaie::1, cfg.ctaie::1,
+      cfg.ctaie::1, cfg.battery::3, 0::1, cfg.bsf::1, cfg.blf::1, cfg.bsei::1, cfg.blie::1>>
+  end
+end

--- a/lib/nerves_time/rtc/abracon/b5ze/date.ex
+++ b/lib/nerves_time/rtc/abracon/b5ze/date.ex
@@ -1,0 +1,66 @@
+defmodule NervesTime.RTC.Abracon.B5ZE.Date do
+  @moduledoc false
+
+  alias NervesTime.RealTimeClock.BCD
+
+  @doc """
+  Return a list of commands for reading the configuration registers
+  """
+  def reads() do
+    # Register 0x03 to 0x09
+    [{:write_read, <<0x03>>, 7}]
+  end
+
+  @doc """
+  Decode register values into a date
+
+  This only returns years between 2000 and 2099.
+  """
+  @spec decode(<<_::56>>) :: {:ok, NaiveDateTime.t()} | {:error, any()}
+  def decode(<<seconds_bcd, minutes_bcd, hours24_bcd, day_bcd, _weekday, month_bcd, year_bcd>>) do
+    {:ok,
+     %NaiveDateTime{
+       second: BCD.to_integer(seconds_bcd),
+       minute: BCD.to_integer(minutes_bcd),
+       hour: BCD.to_integer(hours24_bcd),
+       day: BCD.to_integer(day_bcd),
+       month: BCD.to_integer(month_bcd),
+       year: 2000 + BCD.to_integer(year_bcd)
+     }}
+  end
+
+  def decode(_other), do: {:error, :invalid}
+
+  @doc """
+  Encode the specified date to register values.
+
+  Only dates between 2001 and 2099 are supported. This avoids the need to deal
+  with the leap year special case for 2000. That would involve setting the
+  century bit and that seems like a pointless complexity for a date that has come and gone.
+  """
+  @spec encode(NaiveDateTime.t()) :: {:ok, <<_::56>>} | {:error, any()}
+  def encode(%NaiveDateTime{year: year} = date_time) when year > 2000 and year < 2100 do
+    seconds_bcd = BCD.from_integer(date_time.second)
+    minutes_bcd = BCD.from_integer(date_time.minute)
+    hours24_bcd = BCD.from_integer(date_time.hour)
+    day_bcd = BCD.from_integer(date_time.day)
+    month_bcd = BCD.from_integer(date_time.month)
+    year_bcd = BCD.from_integer(year - 2000)
+    weekday_bcd = Date.day_of_week(date_time) |> BCD.from_integer()
+
+    {:ok,
+     <<
+       seconds_bcd,
+       minutes_bcd,
+       hours24_bcd,
+       day_bcd,
+       weekday_bcd,
+       month_bcd,
+       year_bcd
+     >>}
+  end
+
+  def encode(_invalid_date) do
+    {:error, :invalid_date}
+  end
+end

--- a/test/nerves_time/rtc/abracon/b5ze/configuration_test.exs
+++ b/test/nerves_time/rtc/abracon/b5ze/configuration_test.exs
@@ -1,0 +1,30 @@
+defmodule NervesTime.RTC.Abracon.B5ZE.ConfigurationTest do
+  use ExUnit.Case
+  alias NervesTime.RTC.Abracon.B5ZE.Configuration
+
+  test "decodes configuration" do
+    assert Configuration.decode(<<0, 0, 4>>) ==
+             {:ok,
+              %{
+                af: 0,
+                aie: 0,
+                battery: 0,
+                blf: 1,
+                blie: 0,
+                bsei: 0,
+                bsf: 0,
+                cie: 0,
+                ctaf: 0,
+                ctaie: 0,
+                ctbie: 0,
+                ctbf: 0,
+                sf: 0,
+                sie: 0,
+                sr: 0,
+                stop: 0,
+                twelve_hour: 0,
+                wtaf: 0,
+                wtaie: 0
+              }}
+  end
+end

--- a/test/nerves_time/rtc/abracon/b5ze/date_test.exs
+++ b/test/nerves_time/rtc/abracon/b5ze/date_test.exs
@@ -1,0 +1,20 @@
+defmodule NervesTime.RTC.Abracon.B5ZE.DateTest do
+  use ExUnit.Case
+  alias NervesTime.RTC.Abracon.B5ZE.Date
+
+  test "decodes date" do
+    assert Date.decode(<<2, 3, 4, 5, 2, 6, 7>>) ==
+             {:ok, ~N[2007-06-05 04:03:02]}
+  end
+
+  test "encodes date" do
+    assert Date.encode(~N[2007-06-05 04:03:02]) == {:ok, <<2, 3, 4, 5, 2, 6, 7>>}
+
+    assert Date.encode(~N[2019-10-04 00:07:18]) ==
+             {:ok, <<0x18, 0x07, 0x00, 0x04, 0x05, 0x10, 0x19>>}
+  end
+
+  test "non-21st century dates return errors when encoded" do
+    assert Date.encode(~N[1970-01-01 00:00:11]) == {:error, :invalid_date}
+  end
+end


### PR DESCRIPTION
This is almost identical to the IBO5, but there are just a couple slight explicit model modules and avoid any "auto-magic" since having a slight mishap with time could be very detrimental