### PR TITLE
Fix B5ZE date decoding when clock integrity not guaranteed

### DIFF
--- a/lib/nerves_time/rtc/abracon/b5ze/date.ex
+++ b/lib/nerves_time/rtc/abracon/b5ze/date.ex
@@ -17,6 +17,8 @@ defmodule NervesTime.RTC.Abracon.B5ZE.Date do
   This only returns years between 2000 and 2099.
   """
   @spec decode(<<_::56>>) :: {:ok, NaiveDateTime.t()} | {:error, any()}
+  def decode(<<1::1, _::7, _rem::binary>>), do: {:error, :clock_integrity_not_guaranteed}
+
   def decode(<<seconds_bcd, minutes_bcd, hours24_bcd, day_bcd, _weekday, month_bcd, year_bcd>>) do
     NaiveDateTime.new(
       2000 + BCD.to_integer(year_bcd),

--- a/test/nerves_time/rtc/abracon/b5ze/date_test.exs
+++ b/test/nerves_time/rtc/abracon/b5ze/date_test.exs
@@ -15,6 +15,10 @@ defmodule NervesTime.RTC.Abracon.B5ZE.DateTest do
     assert Date.decode(<<"wat">>) == {:error, :invalid}
   end
 
+  test "does not decode date if clock integrity is not guaranteed" do
+    assert Date.decode(<<160, 3, 4, 5, 2, 6, 7>>) == {:error, :clock_integrity_not_guaranteed}
+  end
+
   test "encodes date" do
     assert Date.encode(~N[2007-06-05 04:03:02]) == {:ok, <<2, 3, 4, 5, 2, 6, 7>>}
 


### PR DESCRIPTION
New B5ZE modules that are not initialized may not have clock integrity and will report invalid times which will continually crash `NervesTime`

So this checks if the integrity bit is set and returns an error which will instruct NervesTime to consider the RTC unset
![image](https://user-images.githubusercontent.com/11321326/156666855-7be38793-b62e-4111-ba45-0df60f6a0f96.png)

/cc @chrisdambrosio