### PR TITLE
Use NaiveDateTime.new when decoding date

### DIFF
--- a/lib/nerves_time/rtc/abracon/b5ze/date.ex
+++ b/lib/nerves_time/rtc/abracon/b5ze/date.ex
@@ -18,15 +18,14 @@ defmodule NervesTime.RTC.Abracon.B5ZE.Date do
   """
   @spec decode(<<_::56>>) :: {:ok, NaiveDateTime.t()} | {:error, any()}
   def decode(<<seconds_bcd, minutes_bcd, hours24_bcd, day_bcd, _weekday, month_bcd, year_bcd>>) do
-    {:ok,
-     %NaiveDateTime{
-       second: BCD.to_integer(seconds_bcd),
-       minute: BCD.to_integer(minutes_bcd),
-       hour: BCD.to_integer(hours24_bcd),
-       day: BCD.to_integer(day_bcd),
-       month: BCD.to_integer(month_bcd),
-       year: 2000 + BCD.to_integer(year_bcd)
-     }}
+    NaiveDateTime.new(
+      2000 + BCD.to_integer(year_bcd),
+      BCD.to_integer(month_bcd),
+      BCD.to_integer(day_bcd),
+      BCD.to_integer(hours24_bcd),
+      BCD.to_integer(minutes_bcd),
+      BCD.to_integer(seconds_bcd)
+    )
   end
 
   def decode(_other), do: {:error, :invalid}

--- a/lib/nerves_time/rtc/abracon/ibo5/date.ex
+++ b/lib/nerves_time/rtc/abracon/ibo5/date.ex
@@ -20,16 +20,15 @@ defmodule NervesTime.RTC.Abracon.IBO5.Date do
   def decode(
         <<hundredths_bcd, seconds_bcd, minutes_bcd, hours24_bcd, day_bcd, month_bcd, year_bcd>>
       ) do
-    {:ok,
-     %NaiveDateTime{
-       microsecond: {BCD.to_integer(hundredths_bcd) * 10000, 2},
-       second: BCD.to_integer(seconds_bcd),
-       minute: BCD.to_integer(minutes_bcd),
-       hour: BCD.to_integer(hours24_bcd),
-       day: BCD.to_integer(day_bcd),
-       month: BCD.to_integer(month_bcd),
-       year: 2000 + BCD.to_integer(year_bcd)
-     }}
+    NaiveDateTime.new(
+      2000 + BCD.to_integer(year_bcd),
+      BCD.to_integer(month_bcd),
+      BCD.to_integer(day_bcd),
+      BCD.to_integer(hours24_bcd),
+      BCD.to_integer(minutes_bcd),
+      BCD.to_integer(seconds_bcd),
+      {BCD.to_integer(hundredths_bcd) * 10000, 2}
+    )
   end
 
   def decode(_other), do: {:error, :invalid}

--- a/test/nerves_time/rtc/abracon/b5ze/date_test.exs
+++ b/test/nerves_time/rtc/abracon/b5ze/date_test.exs
@@ -7,6 +7,14 @@ defmodule NervesTime.RTC.Abracon.B5ZE.DateTest do
              {:ok, ~N[2007-06-05 04:03:02]}
   end
 
+  test "does not return invalid date" do
+    assert Date.decode(<<2, 3, 0, 0, 0, 153, 7>>) == {:error, :invalid_date}
+  end
+
+  test "does not attempt decode on invalid binary" do
+    assert Date.decode(<<"wat">>) == {:error, :invalid}
+  end
+
   test "encodes date" do
     assert Date.encode(~N[2007-06-05 04:03:02]) == {:ok, <<2, 3, 4, 5, 2, 6, 7>>}
 

--- a/test/nerves_time/rtc/abracon/ibo5/date_test.exs
+++ b/test/nerves_time/rtc/abracon/ibo5/date_test.exs
@@ -7,6 +7,14 @@ defmodule NervesTime.RTC.Abracon.IBO5.DateTest do
              {:ok, ~N[2007-06-05 04:03:02.01]}
   end
 
+  test "does not return invalid date" do
+    assert Date.decode(<<1, 2, 0, 0, 0, 0, 7>>) == {:error, :invalid_date}
+  end
+
+  test "does not attempt decode on invalid binary" do
+    assert Date.decode(<<"wat">>) == {:error, :invalid}
+  end
+
   test "encodes date" do
     assert Date.encode(~N[2007-06-05 04:03:02.01]) == {:ok, <<1, 2, 3, 4, 5, 6, 7>>}
 


### PR DESCRIPTION
When manually building a `%NaiveDateTime{}` struct with invalid values you get a fairly silent failure in the form of an `%Inspect.Error{}` struct

```elixir
iex(1)> %NaiveDateTime{year: 0, day: 2, hour: 25, minute: 61, second: 100, month: 0}
%Inspect.Error{
  message: "got FunctionClauseError with message \"no function clause matching in Calendar.ISO.time_to_string/5\" while inspecting %{__struct__: NaiveDateTime, calendar: Calendar.ISO, day: 2, hour: 25, microsecond: {0, 0}, minute: 61, month: 0, second: 100, year: 0}"
}
```

This more-or-less gets handled in NervesTime, but it is a misleading error and takes a minute to parse through the problem.

Instead, this change will rely on the `NaiveDateTime` module to enforce correct dates or return the error tuple as expected.

