### PR TITLE
Drop older Elixir version support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,7 @@ tags: &tags
     1.16.3-erlang-26.2.5.8-alpine-3.21.3,
     1.15.7-erlang-26.1.2-alpine-3.18.4,
     1.14.5-erlang-25.3.2-alpine-3.18.0,
-    1.13.4-erlang-25.3.2-alpine-3.18.0,
-    1.12.3-erlang-24.3.4.11-alpine-3.18.0,
-    1.11.4-erlang-24.3.4.14-alpine-3.18.4
+    1.13.4-erlang-25.3.2-alpine-3.18.0
   ]
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,13 @@
 version: 2.1
 
 latest: &latest
-  pattern: "^1.15.7-erlang-26.*$"
+  pattern: "^1.18.3-erlang-27.*$"
 
 tags: &tags
   [
+    1.18.3-erlang-27.3-alpine-3.21.3,
+    1.17.3-erlang-27.3-alpine-3.21.3,
+    1.16.3-erlang-26.2.5.8-alpine-3.21.3,
     1.15.7-erlang-26.1.2-alpine-3.18.4,
     1.14.5-erlang-25.3.2-alpine-3.18.0,
     1.13.4-erlang-25.3.2-alpine-3.18.0,

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule NervesTime.RTC.Abracon.MixProject do
     [
       app: :nerves_time_rtc_abracon,
       version: @version,
-      elixir: "~> 1.11",
+      elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),


### PR DESCRIPTION
Nerves dropped official support for `< 1.13`, so this changes to match that. It also brings newer CI versions up to speed to be tested